### PR TITLE
feat(events): refactor events and add new events from vkpl

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -71,6 +71,7 @@ class VKPLMessageClient<T extends string> extends EventEmitter<
      * @property debugLog - Если true, то будет выводить логи вебсокета и API в консоль
      */
     public static debugLog: boolean;
+    public static log: boolean = true;
 
     private centrifugeClient: CentrifugeClient<T>;
     private messageParser: VkplMessageParser;
@@ -93,6 +94,7 @@ class VKPLMessageClient<T extends string> extends EventEmitter<
         super();
 
         VKPLMessageClient.debugLog = config.debugLog ?? false;
+        VKPLMessageClient.log = config.log ?? true;
 
         if (config.auth && config.auth !== "readonly") {
             if ("accessToken" in config.auth) {
@@ -235,9 +237,11 @@ class VKPLMessageClient<T extends string> extends EventEmitter<
             api: this.api,
         };
         this.emit("message", ctx);
-        console.log(
-            `[chat:${channel.blogUrl}] ${mappedMessage.user.nick}: ${mappedMessage.message.text}`,
-        );
+        if (VKPLMessageClient.log) {
+            console.log(
+                `[chat:${channel.blogUrl}] ${mappedMessage.user.nick}: ${mappedMessage.message.text}`,
+            );
+        }
     }
 
     private onReward(
@@ -278,9 +282,12 @@ class VKPLMessageClient<T extends string> extends EventEmitter<
             api: this.api,
         };
         this.emit("reward", ctx);
-        console.log(
-            `[reward:${channel.blogUrl}] ${reward.user.nick} reedemed reward: "${reward.reward.name}" ${reward.reward.message ? `with text "${reward.reward.message.text}"` : ""}`,
-        );
+
+        if (VKPLMessageClient.log) {
+            console.log(
+                `[reward:${channel.blogUrl}] ${reward.user.nick} reedemed reward: "${reward.reward.name}" ${reward.reward.message ? `with text "${reward.reward.message.text}"` : ""}`,
+            );
+        }
     }
 
     private onChannelInfo(
@@ -309,9 +316,12 @@ class VKPLMessageClient<T extends string> extends EventEmitter<
         };
 
         this.emit("channel-info", ctx);
-        console.log(
-            `[channelInfo:${channel.blogUrl}] viewers: ${channelInfo.viewers}, isOnline: ${channelInfo.isOnline}, streamId: ${channelInfo.streamId}`,
-        );
+
+        if (VKPLMessageClient.log) {
+            console.log(
+                `[channelInfo:${channel.blogUrl}] viewers: ${channelInfo.viewers}, isOnline: ${channelInfo.isOnline}, streamId: ${channelInfo.streamId}`,
+            );
+        }
     }
 
     private onStreamStatus(
@@ -340,9 +350,12 @@ class VKPLMessageClient<T extends string> extends EventEmitter<
         };
 
         this.emit("stream-status", ctx);
-        console.log(
-            `[streamStatus:${channel.blogUrl}] ${streamStatus.type}, videoId: ${streamStatus.videoId}`,
-        );
+
+        if (VKPLMessageClient.log) {
+            console.log(
+                `[streamStatus:${channel.blogUrl}] ${streamStatus.type}, videoId: ${streamStatus.videoId}`,
+            );
+        }
     }
 
     private onStreamLikeCounter(
@@ -371,9 +384,12 @@ class VKPLMessageClient<T extends string> extends EventEmitter<
         };
 
         this.emit("stream-like-counter", ctx);
-        console.log(
-            `[streamLikeCounter:${channel.blogUrl}] userId: ${likesCount.userId}, counter: ${likesCount.counter}`,
-        );
+
+        if (VKPLMessageClient.log) {
+            console.log(
+                `[streamLikeCounter:${channel.blogUrl}] userId: ${likesCount.userId}, counter: ${likesCount.counter}`,
+            );
+        }
     }
 
     private async onReconnect(): Promise<void> {

--- a/src/client.ts
+++ b/src/client.ts
@@ -79,7 +79,7 @@ class VKPLMessageClient<T extends string> extends EventEmitter<
     public static log: boolean = true;
 
     private centrifugeClient: CentrifugeClient<T>;
-    private messageParser: VkplMessageParser;
+    public messageParser: VkplMessageParser;
 
     private channelNames: T[];
 

--- a/src/services/CentrifugeClient.ts
+++ b/src/services/CentrifugeClient.ts
@@ -223,7 +223,10 @@ export class CentrifugeClient<
             "pub" in message.push &&
             typeof message.push.pub === "object" &&
             message.push.pub !== null &&
-            "type" in message.push.pub
+            "data" in message.push.pub &&
+            typeof message.push.pub.data === "object" &&
+            message.push.pub.data !== null &&
+            "type" in message.push.pub.data
         );
     }
 

--- a/src/services/VkplApi.ts
+++ b/src/services/VkplApi.ts
@@ -26,7 +26,7 @@ export class VkplApi<T extends string> extends EventEmitter<VkplApiEventMap> {
 
         if (auth && "refreshToken" in auth) {
             const untilExpiration =
-                Date.now() - (auth.expiresAt - VkplApi.tokenExpiresShift);
+                auth.expiresAt - VkplApi.tokenExpiresShift - Date.now();
 
             this.refreshTokenTimeout = setTimeout(
                 () => this.refreshToken().catch(console.error),
@@ -642,7 +642,7 @@ export class VkplApi<T extends string> extends EventEmitter<VkplApiEventMap> {
 
             this.refreshTokenTimeout = setTimeout(
                 () => this.refreshToken().catch(console.error),
-                Date.now() - (token.expiresAt - VkplApi.tokenExpiresShift),
+                token.expiresAt - VkplApi.tokenExpiresShift - Date.now(),
             );
 
             return token;
@@ -674,7 +674,7 @@ export class VkplApi<T extends string> extends EventEmitter<VkplApiEventMap> {
             });
 
             if (response.status >= 400) {
-                const error = await response.json();
+                const error = await response.clone().json();
 
                 if (this.isCantSendError(error)) {
                     const delay = Math.max(

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -286,4 +286,14 @@ export namespace APITypes {
         type: CategoryType;
         limit: number;
     };
+
+    export type CantSendError = {
+        error: "cant_send";
+        data: {
+            reasons: {
+                type: "slow_mode_cooldown";
+                remaningTime: number;
+            }[];
+        };
+    };
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -296,4 +296,35 @@ export namespace APITypes {
             }[];
         };
     };
+
+    export type Reaction = {
+        type: string;
+        count: number;
+    };
+
+    export type PinSettings = {
+        messageId: number;
+        reactable: boolean;
+        kind: "permanent" | "stream";
+    };
+
+    export type PinMessage = {
+        writtenAt: number;
+        reactable: boolean;
+        author: TUser;
+        pinner: TUser;
+        id: number;
+        data: TMessageBlock[];
+        period: null;
+        reactions: Reaction[];
+        kind: "permanent" | "stream";
+        reacted: string | null;
+        createdAt: number;
+    };
+
+    export type PinMessageResponse = {
+        data: {
+            pinnedMessage: PinMessage;
+        };
+    };
 }

--- a/src/types/api.v2.ts
+++ b/src/types/api.v2.ts
@@ -209,7 +209,21 @@ export namespace VkWsTypes {
         streamId: string;
     };
 
-    export type WsMessage<T extends Record<string, unknown>> = {
+    export type StreamLikeCounter = {
+        counter: number;
+        userId: number;
+        type: "stream_like_counter";
+    };
+
+    export type WsMessageBody =
+        | ChatMessage
+        | ActionsJournalNewEventRewardDemandMessage
+        | CpRewardDemandMessage
+        | StreamStatus
+        | ChannelInfo
+        | StreamLikeCounter;
+
+    export type WsMessage<T extends WsMessageBody = WsMessageBody> = {
         push: {
             channel: string;
             pub: {

--- a/src/types/api.v2.ts
+++ b/src/types/api.v2.ts
@@ -162,20 +162,28 @@ export namespace VkWsTypes {
         isUnlimited: boolean;
     };
 
-    export type ActionsJournalNewEventRewardDemandMessage = {
-        data: {
-            action_time: number;
-            type: "reward_demand" | string;
-            reward_demand: {
-                status: string;
-                user: User;
-                activationMessage: ChatMessageBlock[];
-                demandId: number;
-                reward: Reward;
-                createdAt: number;
-            };
-        };
+    export type ActionsJournalNewEvent<T> = {
+        data: T;
         type: "actions_journal_new_event";
+    };
+
+    export type ActionsJournalRewardDemandMessage = {
+        action_time: number;
+        type: "reward_demand" | string;
+        reward_demand: {
+            status: string;
+            user: User;
+            activationMessage: ChatMessageBlock[];
+            demandId: number;
+            reward: Reward;
+            createdAt: number;
+        };
+    };
+
+    export type ActionsJournalFollower = {
+        follower: User;
+        action_time: number;
+        type: "following";
     };
 
     export type RewardStatus = "approved" | "pending" | "rejected";
@@ -217,7 +225,8 @@ export namespace VkWsTypes {
 
     export type WsMessageBody =
         | ChatMessage
-        | ActionsJournalNewEventRewardDemandMessage
+        | ActionsJournalNewEvent<ActionsJournalRewardDemandMessage>
+        | ActionsJournalNewEvent<ActionsJournalFollower>
         | CpRewardDemandMessage
         | StreamStatus
         | ChannelInfo

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -243,4 +243,20 @@ export namespace VKPLClientInternal {
     export type StreamLikeCounterEvent<Channel extends string> = [
         ctx: StreamLikeCounterEventContext<Channel>,
     ];
+
+    export type FollowerEventContext<Channel extends string> =
+        Context<Channel> &
+            VkWsTypes.ActionsJournalFollower & {
+                /**
+                 * Отправить сообещние в канал
+                 */
+                sendMessage(
+                    text: string,
+                    mentionUsers?: number[],
+                ): Promise<APITypes.TMessageResponse>;
+            };
+
+    export type FollowerEvent<Channel extends string> = [
+        ctx: FollowerEventContext<Channel>,
+    ];
 }

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -226,4 +226,20 @@ export namespace VKPLClientInternal {
         Context<Channel> & {
             auth: TokenAuth;
         };
+
+    export type StreamLikeCounterEventContext<Channel extends string> =
+        Context<Channel> &
+            VkWsTypes.StreamLikeCounter & {
+                /**
+                 * Отправить сообещние в канал
+                 */
+                sendMessage(
+                    text: string,
+                    mentionUsers?: number[],
+                ): Promise<APITypes.TMessageResponse>;
+            };
+
+    export type StreamLikeCounterEvent<Channel extends string> = [
+        ctx: StreamLikeCounterEventContext<Channel>,
+    ];
 }

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -35,6 +35,7 @@ export namespace VKPLClientInternal {
         auth: Auth;
         wsServer?: string;
         debugLog?: boolean;
+        log?: boolean;
     };
 
     export type Channel = {

--- a/src/utils/deferred-promise.ts
+++ b/src/utils/deferred-promise.ts
@@ -1,10 +1,12 @@
 export class DeferredPromise<T> {
     public promise: Promise<T>;
     public resolve: (value: T) => void = () => {};
+    public reject: (reason?: any) => void = () => {};
 
     constructor() {
-        this.promise = new Promise<T>((resolve) => {
+        this.promise = new Promise<T>((resolve, reject) => {
             this.resolve = resolve;
+            this.reject = reject;
         });
     }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./deferred-promise.js";
+export * from "./sleep.js";

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -1,0 +1,3 @@
+export async function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
- Рефакторинг centrifugo client. Теперь он отвечает только за доставку сообщений
- Клиент теперь обрабатывает сообщения, а не является шлюзом centrifugo client

### События
- Добавлено события нового фолловера
- Добавлено событие обновления счётчика лайков

### Api
- Добавлены методы для взаимодействия с закреплённым сообщением